### PR TITLE
Use plugin.Config when available

### DIFF
--- a/REPOConfig/Entry.cs
+++ b/REPOConfig/Entry.cs
@@ -15,7 +15,7 @@ using UnityEngine;
 
 namespace REPOConfig
 {
-    [BepInPlugin("nickklmao.repoconfig", MOD_NAME, "1.1.1")]
+    [BepInPlugin("nickklmao.repoconfig", MOD_NAME, "1.1.2")]
     internal sealed class Entry : BaseUnityPlugin
     {
         private const string MOD_NAME = "REPO Config";
@@ -45,75 +45,97 @@ namespace REPOConfig
         {
             var repoConfigs = new Dictionary<string, REPOConfigData[]>();
             
-            const BindingFlags ALL_BINDING_FLAGS = (BindingFlags) 60;
-
             var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(assembly => !assembly.IsDynamic).ToArray();
-            
             foreach (var plugin in Chainloader.PluginInfos.Values)
             {
-                var pluginAssembly = assemblies.Single(assembly => assembly.Location == plugin.Location); 
-                
+
                 var configEntries = new List<REPOConfigData>();
-                
-                foreach (var type in pluginAssembly.GetTypes())
+
+                if (plugin.Instance != null)
                 {
-                    foreach (var field in type.GetFields(ALL_BINDING_FLAGS))
-                    {
-                        var isConfigEntryBase = field.FieldType.BaseType == typeof(ConfigEntryBase);
-
-                        if (!isConfigEntryBase || field.GetCustomAttribute<CompilerGeneratedAttribute>() != null)
-                            continue;
-                        
-                        object instance = null;
-
-                        if (type.BaseType == typeof(BaseUnityPlugin))
-                            instance = plugin.Instance;
-                        
-                        if (instance == null && !field.IsStatic)
-                        {
-                            logger.LogDebug($"Field \"{field.Name}\" must be static or instanced under the BaseUnityPlugin class for it to be visible in the settings menu!");
-                            continue;
-                        }
-                        
-                        
-                        if (field.GetValue(instance) is not ConfigEntryBase configEntryBase)
-                            logger.LogDebug($"Field \"{field.Name}\" cannot be null, it will not be visible in the settings menu!");
-                        else
-                            configEntries.Add(new REPOConfigData { repoConfigEntry = field.GetCustomAttribute<REPOConfigEntryAttribute>(), configEntryBase = configEntryBase});
-                    }
-                    
-                    foreach (var property in type.GetProperties(ALL_BINDING_FLAGS))
-                    {
-                        var isConfigEntryBase = property.PropertyType.BaseType == typeof(ConfigEntryBase);
-
-                        if (!isConfigEntryBase)
-                            continue;
-
-                        var getMethod = property.GetGetMethod(true);
-                        
-                        object instance = null;
-
-                        if (type.BaseType == typeof(BaseUnityPlugin))
-                            instance = plugin.Instance;
-                        
-                        if (instance == null && !getMethod.IsStatic)
-                        {
-                            logger.LogDebug($"Property \"{property.Name}\" must be static or instanced under the BaseUnityPlugin class for it to be visible in the settings menu!");
-                            continue;
-                        }
-
-                        if (getMethod.Invoke(null, null) is not ConfigEntryBase configEntryBase)
-                            logger.LogDebug($"Property \"{property.Name}\" cannot be null, it will not be visible in the settings menu!");
-                        else
-                            configEntries.Add(new REPOConfigData { repoConfigEntry = property.GetCustomAttribute<REPOConfigEntryAttribute>(), configEntryBase = configEntryBase});
-                    }
+                    GetConfigEntriesFromPluginInstance(plugin.Instance, configEntries);
+                }
+                else
+                {
+                    WalkTypesForConfigEntries(plugin, configEntries, assemblies);
                 }
                 
+
                 if (configEntries.Count > 0)
                     repoConfigs.TryAdd(plugin.Metadata.Name, configEntries.ToArray());
             }
 
             return repoConfigs;
+        }
+
+        private static void GetConfigEntriesFromPluginInstance(BaseUnityPlugin pluginInstance, List<REPOConfigData> configEntries)
+        {
+            foreach (var configEntry in pluginInstance.Config)
+            {
+                configEntries.Add(new REPOConfigData
+                {
+                    configEntryBase = configEntry.Value,
+                });
+            }
+        }
+
+        private static void WalkTypesForConfigEntries(PluginInfo? plugin, List<REPOConfigData> configEntries, Assembly[]? assemblies)
+        {
+            const BindingFlags ALL_BINDING_FLAGS = (BindingFlags)60;
+            var pluginAssembly = assemblies.Single(assembly => assembly.Location == plugin.Location);
+
+            foreach (var type in pluginAssembly.GetTypes())
+            {
+                foreach (var field in type.GetFields(ALL_BINDING_FLAGS))
+                {
+                    var isConfigEntryBase = field.FieldType.BaseType == typeof(ConfigEntryBase);
+
+                    if (!isConfigEntryBase || field.GetCustomAttribute<CompilerGeneratedAttribute>() != null)
+                        continue;
+
+                    object instance = null;
+
+                    if (type.BaseType == typeof(BaseUnityPlugin))
+                        instance = plugin.Instance;
+
+                    if (instance == null && !field.IsStatic)
+                    {
+                        logger.LogDebug($"Field \"{field.Name}\" must be static or instanced under the BaseUnityPlugin class for it to be visible in the settings menu!");
+                        continue;
+                    }
+
+                    if (field.GetValue(instance) is not ConfigEntryBase configEntryBase)
+                        logger.LogDebug($"Field \"{field.Name}\" cannot be null, it will not be visible in the settings menu!");
+                    else
+                        configEntries.Add(new REPOConfigData { repoConfigEntry = field.GetCustomAttribute<REPOConfigEntryAttribute>(), configEntryBase = configEntryBase });
+                }
+
+                foreach (var property in type.GetProperties(ALL_BINDING_FLAGS))
+                {
+                    var isConfigEntryBase = property.PropertyType.BaseType == typeof(ConfigEntryBase);
+
+                    if (!isConfigEntryBase)
+                        continue;
+
+                    var getMethod = property.GetGetMethod(true);
+
+                    object instance = null;
+
+                    if (type.BaseType == typeof(BaseUnityPlugin))
+                        instance = plugin.Instance;
+
+                    if (instance == null && !getMethod.IsStatic)
+                    {
+                        logger.LogDebug($"Property \"{property.Name}\" must be static or instanced under the BaseUnityPlugin class for it to be visible in the settings menu!");
+                        continue;
+                    }
+
+                    if (getMethod.Invoke(null, null) is not ConfigEntryBase configEntryBase)
+                        logger.LogDebug($"Property \"{property.Name}\" cannot be null, it will not be visible in the settings menu!");
+                    else
+                        configEntries.Add(new REPOConfigData { repoConfigEntry = property.GetCustomAttribute<REPOConfigEntryAttribute>(), configEntryBase = configEntryBase });
+                }
+            }
         }
 
         private static readonly Dictionary<ConfigEntryBase, object> changedEntries = new();


### PR DESCRIPTION
Walking type reflection is not required when the plugin config is still available.
This also fixes settings for plugins that were not designed with REPOConfig in mind (e.g. Unity Explorer)
I have tested it and it does compile and work as intended.
![image](https://github.com/user-attachments/assets/10b3e7ca-4edc-4b8f-9095-b41ef45cd0bb)
